### PR TITLE
Less global prerequisites

### DIFF
--- a/generators/app/templates/_gulpfile.js
+++ b/generators/app/templates/_gulpfile.js
@@ -3,6 +3,7 @@ var tslint  = require('gulp-tslint');
 var exec    = require('child_process').exec;
 var jasmine = require('gulp-jasmine');
 var gulp    = require('gulp-help')(gulp);
+var dotbin  = require('dotbin');
 
 gulp.task('tslint', 'Lints all TypeScript source files', function(){
   return gulp.src('src/**/*.ts')

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -11,6 +11,9 @@
   "files": [
     "lib"
   ],
+  "scripts": {
+    "test": "gulp test"
+  },
   "dependencies": {},
   "devDependencies": {
     "gulp": "^3.9.0",

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -18,6 +18,8 @@
     "gulp-help": "^1.6.0",
     "tslint": "2.*",
     "gulp-jasmine": "^2.0.1",
+    "typescript": "^1.5.0-beta",
+    "dotbin": "^1.0.1",
     "jasmine": "^2.3.1"
   },
   "engines": {


### PR DESCRIPTION
The gulp commands will now work without global installation of typescript and tslint