### PR TITLE
fix thunk already filled errror

### DIFF
--- a/generators/app/templates/_gulpfile.js
+++ b/generators/app/templates/_gulpfile.js
@@ -62,7 +62,9 @@ gulp.task('_build', 'INTERNAL TASK - Compiles all TypeScript source files', func
 });
 
 //run tslint task, then run update-tsconfig and gen-def in parallel, then run _build
-gulp.task('build', 'Compiles all TypeScript source files and updates module references', gulpSequence('tslint', ['update-tsconfig', 'gen-def'], '_build'));
+gulp.task('build', 'Compiles all TypeScript source files and updates module references', function(callback) {
+  gulpSequence('tslint', ['update-tsconfig', 'gen-def'], '_build')(callback);
+});
 
 gulp.task('test', 'Runs the Jasmine test specs', ['build'], function () {
   return gulp.src('test/*.js')


### PR DESCRIPTION
The watch task was running into an issue described here (https://github.com/teambition/gulp-sequence/issues/2).