### PR TITLE
add LICENSE template

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -39,6 +39,8 @@ module.exports = yeoman.generators.Base.extend({
     },
 
     projectfiles: function () {
+      var today = new Date();
+
       if (this.options.gulp) {
         this.fs.copy(
           this.templatePath('_vscode/tasks_gulp.json'),
@@ -88,6 +90,11 @@ module.exports = yeoman.generators.Base.extend({
       this.fs.copy(
         this.templatePath('gitignore'),
         this.destinationPath('.gitignore')
+      );
+      this.fs.copyTpl(
+        this.templatePath('LICENSE'),
+        this.destinationPath('LICENSE'),
+        { year: today.getFullYear().toPrecision(4) }
       );
       this.fs.copy(
         this.templatePath('README.md'),

--- a/generators/app/templates/LICENSE
+++ b/generators/app/templates/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) <%= year %>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-node-typescript",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A minimal Yeoman Generator for creating NodeJS modules using TypeScript",
   "license": "MIT",
   "main": "app/index.js",

--- a/test/test-app.js
+++ b/test/test-app.js
@@ -28,6 +28,7 @@ describe('node-typescript:app with gulp', function () {
       'tslint.json',
       '.editorconfig',
       '.gitignore',
+      'LICENSE',
       'README.md'
     ]);
   });
@@ -55,6 +56,7 @@ describe('node-typescript:app without gulp', function () {
       'tslint.json',
       '.editorconfig',
       '.gitignore',
+      'LICENSE',
       'README.md'
     ]);
   });


### PR DESCRIPTION
Abiding with GitHub's repo initialization with `.gitignore`, `README`, and `LICENSE` files. I suppose they consider those the bare minimum. 
