### PR TITLE
Added travis and coveralls configurations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Available tasks
 - I use _npm_ to fetch type definitions making life so much easier. You can find more information on [https://blogs.msdn.microsoft.com/typescript/2016/06/15/the-future-of-declaration-files/](https://blogs.msdn.microsoft.com/typescript/2016/06/15/the-future-of-declaration-files/).
 - I use _mocha_ as testing framework as it allows easier test runs from command line. Also, one of the most important things regarding testing is **now you can write tests in TypeScript itself**. The out-of-box configuration includes use of [ts-node](https://github.com/TypeStrong/ts-node) as mocha compiler allowing executing specs written in TypeScript without compiling them first.
 - I need **no global dependencies**. Every dependency such as _TypeScript_ and _tslint_ is installed as local dev dependency allowing you to freely use different versions of these for different modules.
-- I provide test covergae support using _istanbul_.
+- I provide test coverage support using _istanbul_.
 - I provide nice integration with [VS Code editor](https://code.visualstudio.com/). I configure `build`, `clean`, `lint`, `coverage` and `test` tasks that you can run using `Run Task` option.
 
 ## License

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -63,6 +63,11 @@ module.exports = yeoman.generators.Base.extend({
           this.destinationPath('gulpfile.js'),
           { appname: _.kebabCase(path.basename(process.cwd())) }
         );
+
+        this.fs.copy(
+          this.templatePath('README_gulp.md'),
+          this.destinationPath('README.md')
+        );
       } else {
         this.fs.copy(
           this.templatePath('_vscode/tasks.json'),
@@ -78,6 +83,11 @@ module.exports = yeoman.generators.Base.extend({
         this.fs.copy(
           this.templatePath('travis.yml'),
           this.destinationPath('.travis.yml')
+        );
+
+        this.fs.copy(
+          this.templatePath('README.md'),
+          this.destinationPath('README.md')
         );
       }
 
@@ -105,10 +115,6 @@ module.exports = yeoman.generators.Base.extend({
         this.templatePath('LICENSE'),
         this.destinationPath('LICENSE'),
         { year: today.getFullYear().toPrecision(4) }
-      );
-      this.fs.copy(
-        this.templatePath('README.md'),
-        this.destinationPath('README.md')
       );
     }
   },

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -74,11 +74,16 @@ module.exports = yeoman.generators.Base.extend({
           this.destinationPath('package.json'),
           { appname: _.kebabCase(path.basename(process.cwd())) }
         );
+
+        this.fs.copy(
+          this.templatePath('travis.yml'),
+          this.destinationPath('.travis.yml')
+        );
       }
 
       this.fs.copy(
-          this.templatePath('_vscode/settings.json'),
-          this.destinationPath('.vscode/settings.json')
+        this.templatePath('_vscode/settings.json'),
+        this.destinationPath('.vscode/settings.json')
       );
       this.fs.copy(
         this.templatePath('_tsconfig.json'),

--- a/generators/app/templates/README_gulp.md
+++ b/generators/app/templates/README_gulp.md
@@ -1,7 +1,3 @@
-[![Build Status](https://travis-ci.org/{{github-user-name}}/{{github-app-name}}.svg?branch=master)](https://travis-ci.org/{{github-user-name}}/{{github-app-name}}.svg?branch=master)
-[![Coverage Status](https://coveralls.io/repos/github/{{github-user-name}}/{{github-app-name}}/badge.svg?branch=master)](https://coveralls.io/github/{{github-user-name}}/{{github-app-name}}?branch=master)
-[![MIT license](http://img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
-
 # Using this module in other modules
 
 Here is a quick example of how this module can be used in other modules. The [TypeScript Module Resolution Logic](https://www.typescriptlang.org/docs/handbook/module-resolution.html) makes it quite easy. The file `src/index.ts` is a [barrel](https://basarat.gitbooks.io/typescript/content/docs/tips/barrel.html) that re-exports selected exports from other files. The _package.json_ file contains `main` attribute that points to the generated `lib/index.js` file and `typings` attribute that points to the generated `lib/index.d.ts` file.
@@ -27,8 +23,3 @@ const Greeter = require('my-amazing-lib').Greeter;
 const greeter = new Greeter('World!');
 greeter.greet();
 ```
-
-## Setting travis and coveralls badges
-1. Sign in to [travis](https://travis-ci.org/) and activate the build for your project.
-2. Sign in to [coveralls](https://coveralls.io/) and activate the build for your project.
-3. Replace {{github-user-name}}/{{github-app-name}} with your repo details like: "ospatil/generator-node-typescript".

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -27,13 +27,13 @@
   "devDependencies": {
     "@types/chai": "^3.0.0",
     "@types/mocha": "^2.0.0",
-    "@types/node": "^6.0.0",
+    "@types/node": "^7.0.0",
     "chai": "^3.0.0",
     "mocha": "^3.0.0",
     "nyc": "^10.0.0",
     "rimraf": "^2.0.0",
-    "ts-node": "^2.0.0",
-    "tslint": "^4.0.0",
+    "ts-node": "^3.0.0",
+    "tslint": "^5.0.0",
     "typescript": "^2.0.0",
     "coveralls": "^2.0.0"
   },

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -18,7 +18,7 @@
     "lint": "tslint --force --format verbose \"src/**/*.ts\"",
     "build": "npm run clean && npm run lint && echo Using TypeScript && tsc --version && tsc --pretty",
     "test": "npm run build && mocha --compilers ts:ts-node/register --recursive 'test/**/*-spec.ts'",
-    "coverage": "nyc --reporter=text --reporter=html mocha --compilers ts:ts-node/register",
+    "coverage": "nyc --reporter=text --reporter=html --reporter=lcov mocha --compilers ts:ts-node/register",
     "watch": "npm run build -- --watch",
     "watch:test": "npm run test -- --watch"
   },
@@ -34,7 +34,8 @@
     "rimraf": "^2.0.0",
     "ts-node": "^2.0.0",
     "tslint": "^4.0.0",
-    "typescript": "^2.0.0"
+    "typescript": "^2.0.0",
+    "coveralls": "^2.0.0"
   },
   "engines": {
     "node": ">=4.0.0"

--- a/generators/app/templates/src/greeter.ts
+++ b/generators/app/templates/src/greeter.ts
@@ -8,4 +8,4 @@ export class Greeter {
   public greet() {
     return "Bonjour, " + this.greeting + "!";
   }
-};
+}

--- a/generators/app/templates/travis.yml
+++ b/generators/app/templates/travis.yml
@@ -1,0 +1,9 @@
+language: node_js
+node_js:
+  - '6'
+  - '4'
+script:
+  - npm run build  # build
+  - npm run coverage  # run mocha unit tests with coverage
+after_script:
+  - 'cat coverage/lcov.info | ./node_modules/.bin/coveralls' # sends the coverage report to coveralls

--- a/test/test-app.js
+++ b/test/test-app.js
@@ -54,6 +54,7 @@ describe('node-typescript:app without gulp', function () {
       'package.json',
       'tsconfig.json',
       'tslint.json',
+      '.travis.yml',
       '.editorconfig',
       '.gitignore',
       'LICENSE',


### PR DESCRIPTION
Hi there, as discussed  #22  the PR follows
- Added travis and coveralls configurations only when using npm tasks (couldn't find the coverage task when using gulp).
- Fixed a very small typo in the Readme file.

If you like I could also change:
- Update the following libraries to the latest version
  - @types/node => from 6.0.0 to 7.0.0
  - ts-node => from 2.0.0 to 3.0.0
  - tslint => from 4.0.0 to 5.0.0
- Add the travis and the coveralls links to the readme file
- Add the badges for travis and coveralls to the default Readme file

Let me know if its all good,
Thanks,
Valter