### PR TITLE
prevent mocha overwriting

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -124,7 +124,7 @@ module.exports = Generator.extend({
             this.templatePath('travis_mocha.yml'),
             this.destinationPath('.travis.yml')
           );
-        } if (this.options.ava) { // copy ava files
+        } else if (this.options.ava) { // copy ava files
           this.fs.copyTpl(
             this.templatePath('_package_ava.json'),
             this.destinationPath('package.json'),


### PR DESCRIPTION
With the `--mocha` option, the `package.json` (etc) was getting overwritten with the `jest` file(s).