### PR TITLE
no jest-cli dependency, so use jest/bin

### DIFF
--- a/generators/app/templates/_vscode/launch.json
+++ b/generators/app/templates/_vscode/launch.json
@@ -21,7 +21,7 @@
       "type": "node",
       "request": "launch",
       "name": "Debug test",
-      "program": "${workspaceRoot}/node_modules/jest-cli/bin/jest.js",
+      "program": "${workspaceRoot}/node_modules/jest/bin/jest.js",
       "args": [
         "--findRelatedTests",
         "${relativeFile}",


### PR DESCRIPTION
Corrects a problem when I generated a brand new project and tried to debug the generated `greeter-spec.ts`:  

![image](https://user-images.githubusercontent.com/14940561/32780504-7b6b3f2c-c90f-11e7-9f12-b667a42e2127.png)

Alternatively, `jest-cli` could be a dev-dependency. 

Also, I left the duplicate `.js.js` here:
`Attribute 'program' does not exist ('c:\Users\xxx\Work\Dev\node\template/node_modules/jest-cli/bin/jest.js.js').`

Since it appears that this does not cause any problems after `jest-cli` becomes `jest` 
